### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/PMD.yml
+++ b/.github/workflows/PMD.yml
@@ -1,5 +1,8 @@
 name: PMD Apex Scan
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/nirajanDevHub108/salesforceDev_Repo/security/code-scanning/1](https://github.com/nirajanDevHub108/salesforceDev_Repo/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block at the workflow level (to apply to all jobs) or within the specific job (`pmd-scan`). Since the workflow primarily reads repository contents and does not seem to require write permissions, we will set `contents: read` at the workflow level. This ensures the least privilege is granted to the GITHUB_TOKEN used in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
